### PR TITLE
Selectize column limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # New Selectize Plugin Update for Saltcorn
-This update introduces enhanced functionality to the Selectize plugin in Saltcorn, focusing on customizable AJAX responses and optimized data fetching. It allows users to format dropdown labels dynamically (e.g., combining fields like name and CNPJ) and limit fetched columns for better performance, without altering the database. The backend modifications ensure the API supports these features securely.
+This update introduces enhanced functionality to the Selectize plugin in Saltcorn, focusing on customizable AJAX responses and optimized data fetching. It allows users to format dropdown labels dynamically (e.g., combining fields like name and RG) and limit fetched columns for better performance, without altering the database. The backend modifications ensure the API supports these features securely.
 
 ## Key Changes
 
-- **✅AJAX Response Formatting:** Customize how options appear in the dropdown using placeholders like {nome} - {cnpj}.
+- **✅AJAX Response Formatting:** Customize how options appear in the dropdown using placeholders like {nome} - {rg}.
 - **✅Column Limiting:** Specify fields to fetch (e.g., "id,name,rg") to reduce data transfer.
 - **❌Multiple search support:** Search across multiple fields (e.g., partial matches on name, RG, id) for more flexible queries.
 - **❌No bug fixes:** Unresolved syntax issues, dynamic "where" filtering, and bidirectional autofill (not implemented).

--- a/README.md
+++ b/README.md
@@ -45,174 +45,197 @@ This README details backend modifications to `packages/server/routes/api.js` for
 1. **Open api.js**: Navigate to `packages/server/routes/api.js`.
 
 2. **Add Multisearch Logic**: In the GET /:tableName/ handler, change for:
-   ```javascript
-        router.get(
-        "/:tableName/",
-        //passport.authenticate("api-bearer", { session: false }),
-        error_catcher(async (req, res, next) => {
-            let { tableName } = req.params;
-            const {
-            fields: queryFields,
-            columns,  // Alias for backward compatibility if needed
-            versioncount,
-            limit,
-            offset,
-            sortBy,
-            sortDesc,
-            approximate,
-            dereference,
-            tabulator_pagination_format,
-            ...req_query0
-            } = req.query;
+```javascript
+router.get(
+"/:tableName/",
+//passport.authenticate("api-bearer", { session: false }),
+error_catcher(async (req, res, next) => {
+    let { tableName } = req.params;
+    const {
+    fields: queryFields,
+    columns,  // Alias for backward compatibility if needed
+    versioncount,
+    limit,
+    offset,
+    sortBy,
+    sortDesc,
+    approximate,
+    dereference,
+    tabulator_pagination_format,
+    ...req_query0
+    } = req.query;
 
-            let req_query = req_query0;
-            let tabulator_size, tabulator_page, tabulator_sort, tabulator_dir;
-            if (tabulator_pagination_format) {
-            const { page, size, sort, ...rq } = req_query0;
-            req_query = rq;
-            tabulator_page = page;
-            tabulator_size = size;
-            tabulator_sort = sort?.[0]?.field;
-            tabulator_dir = sort?.[0]?.dir;
-            }
-            if (typeof limit !== "undefined")
-            if (isNaN(limit) || !validateNumberMin(limit, 1)) {
-                getState().log(3, `API get ${tableName} Invalid limit parameter`);
-                return res.status(400).send({ error: "Invalid limit parameter" });
-            }
-            if (typeof offset !== "undefined")
-            if (isNaN(offset) || !validateNumberMin(offset, 0)) {
-                getState().log(3, `API get ${tableName} Invalid offset parameter`);
-                return res.status(400).send({ error: "Invalid offset parameter" });
-            }
-            const strictIntId = strictParseInt(tableName);
-            let table = Table.findOne(
-            strictIntId ? { id: strictParseInt(tableName) } : { name: tableName }
-            );
-            if (strictIntId && !table) table = Table.findOne({ name: tableName });
-            if (!table) {
-            getState().log(3, `API get ${tableName} table not found`);
-            getState().log(
-                6,
-                `API get failure additonal info: URL=${req.originalUrl}${
-                getState().getConfig("log_ip_address", false) ? ` IP=${req.ip}` : ""
-                }`
-            );
-            res.status(404).json({ error: req.__("Not found") });
+    let req_query = req_query0;
+    let tabulator_size, tabulator_page, tabulator_sort, tabulator_dir;
+    if (tabulator_pagination_format) {
+    const { page, size, sort, ...rq } = req_query0;
+    req_query = rq;
+    tabulator_page = page;
+    tabulator_size = size;
+    tabulator_sort = sort?.[0]?.field;
+    tabulator_dir = sort?.[0]?.dir;
+    }
+    if (typeof limit !== "undefined")
+    if (isNaN(limit) || !validateNumberMin(limit, 1)) {
+        getState().log(3, `API get ${tableName} Invalid limit parameter`);
+        return res.status(400).send({ error: "Invalid limit parameter" });
+    }
+    if (typeof offset !== "undefined")
+    if (isNaN(offset) || !validateNumberMin(offset, 0)) {
+        getState().log(3, `API get ${tableName} Invalid offset parameter`);
+        return res.status(400).send({ error: "Invalid offset parameter" });
+    }
+    const strictIntId = strictParseInt(tableName);
+    let table = Table.findOne(
+    strictIntId ? { id: strictParseInt(tableName) } : { name: tableName }
+    );
+    if (strictIntId && !table) table = Table.findOne({ name: tableName });
+    if (!table) {
+    getState().log(3, `API get ${tableName} table not found`);
+    getState().log(
+        6,
+        `API get failure additonal info: URL=${req.originalUrl}${
+        getState().getConfig("log_ip_address", false) ? ` IP=${req.ip}` : ""
+        }`
+    );
+    res.status(404).json({ error: req.__("Not found") });
+    return;
+    }
+    const orderByField =
+    (sortBy || tabulator_sort) && table.getField(sortBy || tabulator_sort);
+
+    const use_limit = tabulator_pagination_format
+    ? +tabulator_size
+    : limit && +limit;
+    const use_offset = tabulator_pagination_format
+    ? +tabulator_size * (+tabulator_page - 1)
+    : offset && +offset;
+
+    await passport.authenticate(
+    ["api-bearer", "jwt"],
+    { session: false },
+    async function (err, user, info) {
+        if (accessAllowedRead(req, user, table, true)) {
+        let rows;
+        if (versioncount === "on") {
+            const joinOpts = {
+            forUser: req.user || user || { role_id: 100 },
+            forPublic: !(req.user || user),
+            limit: use_limit,
+            offset: use_offset,
+            orderDesc:
+                (sortDesc && sortDesc !== "false") || tabulator_dir == "desc",
+            orderBy: orderByField?.name || "id",
+            aggregations: {
+                _versions: {
+                table: table.name + "__history",
+                ref: table.pk_name,
+                field: table.pk_name,
+                aggregate: "count",
+                },
+            },
+            };
+            rows = await table.getJoinedRows(joinOpts);
+        } else {
+            const tbl_fields = table.getFields();
+            readState(req_query, tbl_fields, req);
+            const qstate = stateFieldsToWhere({
+            fields: tbl_fields,
+            approximate: !!approximate,
+            state: req_query,
+            table,
+            prefix: "a.",
+            });
+            const joinFields = {};
+            const derefs = Array.isArray(dereference)
+            ? dereference
+            : !dereference
+                ? []
+                : [dereference];
+            derefs.forEach((f) => {
+            const field = table.getField(f);
+            if (field?.attributes?.summary_field)
+                joinFields[`${f}_${field?.attributes?.summary_field}`] = {
+                ref: f,
+                target: field?.attributes?.summary_field,
+                };
+            });
+            try {
+            rows = await table.getJoinedRows({
+                where: qstate,
+                joinFields,
+                limit: use_limit,
+                offset: use_offset,
+                orderDesc:
+                (sortDesc && sortDesc !== "false") || tabulator_dir == "desc",
+                orderBy: orderByField?.name || undefined,
+                forPublic: !(req.user || user),
+                forUser: req.user || user,
+            });
+            } catch (e) {
+            console.error(e);
+            res.json({ error: "API error" });
             return;
             }
-            const orderByField =
-            (sortBy || tabulator_sort) && table.getField(sortBy || tabulator_sort);
+        }
 
-            const use_limit = tabulator_pagination_format
-            ? +tabulator_size
-            : limit && +limit;
-            const use_offset = tabulator_pagination_format
-            ? +tabulator_size * (+tabulator_page - 1)
-            : offset && +offset;
-
-            await passport.authenticate(
-            ["api-bearer", "jwt"],
-            { session: false },
-            async function (err, user, info) {
-                if (accessAllowedRead(req, user, table, true)) {
-                let rows;
-                if (versioncount === "on") {
-                    const joinOpts = {
-                    forUser: req.user || user || { role_id: 100 },
-                    forPublic: !(req.user || user),
-                    limit: use_limit,
-                    offset: use_offset,
-                    orderDesc:
-                        (sortDesc && sortDesc !== "false") || tabulator_dir == "desc",
-                    orderBy: orderByField?.name || "id",
-                    aggregations: {
-                        _versions: {
-                        table: table.name + "__history",
-                        ref: table.pk_name,
-                        field: table.pk_name,
-                        aggregate: "count",
-                        },
-                    },
-                    };
-                    rows = await table.getJoinedRows(joinOpts);
-                } else {
-                    const tbl_fields = table.getFields();
-                    readState(req_query, tbl_fields, req);
-                    const qstate = stateFieldsToWhere({
-                    fields: tbl_fields,
-                    approximate: !!approximate,
-                    state: req_query,
-                    table,
-                    prefix: "a.",
-                    });
-                    const searchTerm = req.query.search;
-                    const searchFields = req.query.multisearch ? req.query.multisearch.split(',').map(c => c.trim()).filter(Boolean) : [];
-                    if (searchTerm && searchFields.length > 0) {
-                        qstate.or = searchFields.map(field => ({ [field]: { ilike: `%${searchTerm}%` } }));
-                    }
-                    const joinFields = {};
-                    const derefs = Array.isArray(dereference)
-                    ? dereference
-                    : !dereference
-                        ? []
-                        : [dereference];
-                    derefs.forEach((f) => {
-                    const field = table.getField(f);
-                    if (field?.attributes?.summary_field)
-                        joinFields[`${f}_${field?.attributes?.summary_field}`] = {
-                        ref: f,
-                        target: field?.attributes?.summary_field,
-                        };
-                    });
-                    try {
-                    rows = await table.getJoinedRows({
-                        where: qstate,
-                        joinFields,
-                        limit: use_limit,
-                        offset: use_offset,
-                        orderDesc:
-                        (sortDesc && sortDesc !== "false") || tabulator_dir == "desc",
-                        orderBy: orderByField?.name || undefined,
-                        forPublic: !(req.user || user),
-                        forUser: req.user || user,
-                    });
-                    } catch (e) {
-                    console.error(e);
-                    res.json({ error: "API error" });
-                    return;
-                    }
-                }
-
-                // Limit columns if 'colunas' is provided (your custom logic)
-                if (req.query.colunas && typeof req.query.colunas === 'string') {
-                    const requested = req.query.colunas.split(',').map(c => c.trim()).filter(Boolean);
-                    if (requested.length > 0 && requested.length <= 10) {
-                    rows = rows.map(row => 
-                        Object.fromEntries(
-                        Object.entries(row).filter(([key]) => requested.includes(key))
-                        )
-                    );
-                    }
-                }
-
-                if (tabulator_pagination_format) {
-                    const count = await table.countRows();
-                    if (count === null)
-                    res.json({
-                        data: rows.map(limitFields(queryFields || columns)),
-                    });
-                    else
-                    res.json({
-                        last_page: Math.ceil(count / +tabulator_size),
-                        data: rows.map(limitFields(queryFields || columns)),
-                    });
-                } else res.json({ success: rows.map(limitFields(queryFields || columns)) });
-                } else {
-                getState().log(3, `API get ${table.name} not authorized`);
-                res.status(401).json({ error: req.__("Not authorized") });
-                }
+        // Process colunas for DB-level limiting
+        let selectFields = tbl_fields.map(f => f.name);
+        if (req.query.colunas && typeof req.query.colunas === 'string') {
+        let requested = req.query.colunas.split(',').map(c => c.trim()).filter(Boolean);
+        if (requested.length > 0 && requested.length <= 10) {
+            const validFields = tbl_fields.map(f => f.name);
+            requested = requested.filter(c => validFields.includes(c));
+            if (requested.length > 0) {
+            selectFields = requested;
+            getState().log(5, `API GET ${table.name} limited to columns: ${selectFields.join(', ')}`);
             }
-            )(req, res, next);
-        })
-        );
+        }
+        }
+
+        const opts = {
+        where: qstate,
+        joinFields,
+        limit: use_limit,
+        offset: use_offset,
+        orderDesc: (sortDesc && sortDesc !== "false") || tabulator_dir == "desc",
+        orderBy: orderByField?.name || undefined,
+        forPublic: !(req.user || user),
+        forUser: req.user || user,
+        fields: selectFields  // DB-level limiting here
+        };
+
+        if (versioncount === "on") {
+        opts.aggregations = {
+            _versions: {
+            table: table.name + "__history",
+            ref: table.pk_name,
+            field: table.pk_name,
+            aggregate: "count",
+            },
+        };
+        rows = await table.getJoinedRows(opts);
+        } else {
+        rows = await table.getJoinedRows(opts);  // Use opts with fields
+        }
+
+        if (tabulator_pagination_format) {
+            const count = await table.countRows();
+            if (count === null)
+            res.json({
+                data: rows.map(limitFields(queryFields || columns)),
+            });
+            else
+            res.json({
+                last_page: Math.ceil(count / +tabulator_size),
+                data: rows.map(limitFields(queryFields || columns)),
+            });
+        } else res.json({ success: rows.map(limitFields(queryFields || columns)) });
+        } else {
+        getState().log(3, `API get ${table.name} not authorized`);
+        res.status(401).json({ error: req.__("Not authorized") });
+        }
+    }
+    )(req, res, next);
+})
+);

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@ This update introduces enhanced functionality to the Selectize plugin in Saltcor
 
 ## Key Changes
 
-- **AJAX Response Formatting:** Customize how options appear in the dropdown using placeholders like {nome} - {cnpj}.
-- **Column Limiting:** Specify fields to fetch (e.g., "id,nome,cnpj") to reduce data transfer.
-- **Multisearch Support:** Search across multiple fields (e.g., partial matches in name or CNPJ) for more flexible queries.
-- **Bug Fixes:** Resolved syntax issues, dynamic "where" filtering, and bidirectional autofill (removed in favor of formatting).
+- **✅AJAX Response Formatting:** Customize how options appear in the dropdown using placeholders like {nome} - {cnpj}.
+- **✅Column Limiting:** Specify fields to fetch (e.g., "id,name,rg") to reduce data transfer.
+- **❌Multiple search support:** Search across multiple fields (e.g., partial matches on name, RG, id) for more flexible queries.
+- **❌No bug fixes:** Unresolved syntax issues, dynamic "where" filtering, and bidirectional autofill (not implemented).
 
 These improvements make Selectize more efficient for large datasets and complex forms, with no breaking changes to existing setups.
 
@@ -22,13 +22,11 @@ For full details on backend integration, see the README file content below.
 This survey provides an in-depth overview of the Selectize plugin update for Saltcorn, including rationale, code changes, backend modifications, testing guidelines, and potential extensions. The update addresses user feedback on AJAX customization, performance optimization, and search flexibility, making it a significant enhancement for form-based applications. It removes deprecated autofill features in favor of response formatting, aligning with modern UX patterns in dropdowns.
 
 ## Update Rationale and Features
-The original Selectize plugin limited AJAX responses to a single summary field, leading to issues like incomplete data display or inefficient fetches. This version introduces dynamic formatting (e.g., {nome} - {cnpj}) using string replacement in JavaScript, allowing rich labels without DB changes. Column limiting reduces payload size, crucial for mobile or high-latency environments. Multisearch enables OR-based filtering across fields, solving the "search by name but param is cnpj" problem by dynamically building queries.
+The original Selectize plugin limited AJAX responses to a single summary field, leading to issues like incomplete data display or inefficient fetches. This version introduces dynamic formatting (e.g., {name} - {rg}) using string replacement in JavaScript, allowing rich labels without DB changes. Column limiting reduces payload size, crucial for mobile or high-latency environments. Multisearch enables OR-based filtering across fields, solving the "search by name but param is cnpj" problem by dynamically building queries.
 Key enhancements:
 
 - **Response Formatting:** Uses regex replacement for placeholders, supporting any fetched column.
 - **Column Fetching:** Integrates with backend colunas param for selective SELECT.
-- **Multisearch:** Backend OR clauses for partial matches, with frontend param passing.
-- I was unable to implement autocomplete (autofill) because there were several bugs.
 
 These changes improve usability without requiring schema modifications, though for very large tables, consider indexing search fields.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,218 @@
+# New Selectize Plugin Update for Saltcorn
+This update introduces enhanced functionality to the Selectize plugin in Saltcorn, focusing on customizable AJAX responses and optimized data fetching. It allows users to format dropdown labels dynamically (e.g., combining fields like name and CNPJ) and limit fetched columns for better performance, without altering the database. The backend modifications ensure the API supports these features securely.
+
+## Key Changes
+
+- **AJAX Response Formatting:** Customize how options appear in the dropdown using placeholders like {nome} - {cnpj}.
+- **Column Limiting:** Specify fields to fetch (e.g., "id,nome,cnpj") to reduce data transfer.
+- **Multisearch Support:** Search across multiple fields (e.g., partial matches in name or CNPJ) for more flexible queries.
+- **Bug Fixes:** Resolved syntax issues, dynamic "where" filtering, and bidirectional autofill (removed in favor of formatting).
+
+These improvements make Selectize more efficient for large datasets and complex forms, with no breaking changes to existing setups.
+
+## Installation and Upgrade
+
+- Reinstall the plugin in Saltcorn via the admin interface.
+- Apply backend changes to packages/server/routes/api.js as detailed in the README below.
+- Test with a key field: Enable AJAX, set "Columns to fetch" and "AJAX response format".
+
+For full details on backend integration, see the README file content below.
+
+# Comprehensive Survey on Selectize Plugin Update and Backend Integration
+This survey provides an in-depth overview of the Selectize plugin update for Saltcorn, including rationale, code changes, backend modifications, testing guidelines, and potential extensions. The update addresses user feedback on AJAX customization, performance optimization, and search flexibility, making it a significant enhancement for form-based applications. It removes deprecated autofill features in favor of response formatting, aligning with modern UX patterns in dropdowns.
+
+## Update Rationale and Features
+The original Selectize plugin limited AJAX responses to a single summary field, leading to issues like incomplete data display or inefficient fetches. This version introduces dynamic formatting (e.g., {nome} - {cnpj}) using string replacement in JavaScript, allowing rich labels without DB changes. Column limiting reduces payload size, crucial for mobile or high-latency environments. Multisearch enables OR-based filtering across fields, solving the "search by name but param is cnpj" problem by dynamically building queries.
+Key enhancements:
+
+- **Response Formatting:** Uses regex replacement for placeholders, supporting any fetched column.
+- **Column Fetching:** Integrates with backend colunas param for selective SELECT.
+- **Multisearch:** Backend OR clauses for partial matches, with frontend param passing.
+- I was unable to implement autocomplete (autofill) because there were several bugs.
+
+These changes improve usability without requiring schema modifications, though for very large tables, consider indexing search fields.
+
+
+# Selectize Plugin for Saltcorn - Update Guide
+
+This README details backend modifications to `packages/server/routes/api.js` for the new Selectize version, enabling column limiting, multisearch, and dynamic response formatting.
+
+## Prerequisites
+- Saltcorn version 1.0.0 or higher.
+- Selectize plugin installed and updated with the new index.js.
+
+## Step-by-Step Backend Changes
+1. **Open api.js**: Navigate to `packages/server/routes/api.js`.
+
+2. **Add Multisearch Logic**: In the GET /:tableName/ handler, change for:
+   ```javascript
+        router.get(
+        "/:tableName/",
+        //passport.authenticate("api-bearer", { session: false }),
+        error_catcher(async (req, res, next) => {
+            let { tableName } = req.params;
+            const {
+            fields: queryFields,
+            columns,  // Alias for backward compatibility if needed
+            versioncount,
+            limit,
+            offset,
+            sortBy,
+            sortDesc,
+            approximate,
+            dereference,
+            tabulator_pagination_format,
+            ...req_query0
+            } = req.query;
+
+            let req_query = req_query0;
+            let tabulator_size, tabulator_page, tabulator_sort, tabulator_dir;
+            if (tabulator_pagination_format) {
+            const { page, size, sort, ...rq } = req_query0;
+            req_query = rq;
+            tabulator_page = page;
+            tabulator_size = size;
+            tabulator_sort = sort?.[0]?.field;
+            tabulator_dir = sort?.[0]?.dir;
+            }
+            if (typeof limit !== "undefined")
+            if (isNaN(limit) || !validateNumberMin(limit, 1)) {
+                getState().log(3, `API get ${tableName} Invalid limit parameter`);
+                return res.status(400).send({ error: "Invalid limit parameter" });
+            }
+            if (typeof offset !== "undefined")
+            if (isNaN(offset) || !validateNumberMin(offset, 0)) {
+                getState().log(3, `API get ${tableName} Invalid offset parameter`);
+                return res.status(400).send({ error: "Invalid offset parameter" });
+            }
+            const strictIntId = strictParseInt(tableName);
+            let table = Table.findOne(
+            strictIntId ? { id: strictParseInt(tableName) } : { name: tableName }
+            );
+            if (strictIntId && !table) table = Table.findOne({ name: tableName });
+            if (!table) {
+            getState().log(3, `API get ${tableName} table not found`);
+            getState().log(
+                6,
+                `API get failure additonal info: URL=${req.originalUrl}${
+                getState().getConfig("log_ip_address", false) ? ` IP=${req.ip}` : ""
+                }`
+            );
+            res.status(404).json({ error: req.__("Not found") });
+            return;
+            }
+            const orderByField =
+            (sortBy || tabulator_sort) && table.getField(sortBy || tabulator_sort);
+
+            const use_limit = tabulator_pagination_format
+            ? +tabulator_size
+            : limit && +limit;
+            const use_offset = tabulator_pagination_format
+            ? +tabulator_size * (+tabulator_page - 1)
+            : offset && +offset;
+
+            await passport.authenticate(
+            ["api-bearer", "jwt"],
+            { session: false },
+            async function (err, user, info) {
+                if (accessAllowedRead(req, user, table, true)) {
+                let rows;
+                if (versioncount === "on") {
+                    const joinOpts = {
+                    forUser: req.user || user || { role_id: 100 },
+                    forPublic: !(req.user || user),
+                    limit: use_limit,
+                    offset: use_offset,
+                    orderDesc:
+                        (sortDesc && sortDesc !== "false") || tabulator_dir == "desc",
+                    orderBy: orderByField?.name || "id",
+                    aggregations: {
+                        _versions: {
+                        table: table.name + "__history",
+                        ref: table.pk_name,
+                        field: table.pk_name,
+                        aggregate: "count",
+                        },
+                    },
+                    };
+                    rows = await table.getJoinedRows(joinOpts);
+                } else {
+                    const tbl_fields = table.getFields();
+                    readState(req_query, tbl_fields, req);
+                    const qstate = stateFieldsToWhere({
+                    fields: tbl_fields,
+                    approximate: !!approximate,
+                    state: req_query,
+                    table,
+                    prefix: "a.",
+                    });
+                    const searchTerm = req.query.search;
+                    const searchFields = req.query.multisearch ? req.query.multisearch.split(',').map(c => c.trim()).filter(Boolean) : [];
+                    if (searchTerm && searchFields.length > 0) {
+                        qstate.or = searchFields.map(field => ({ [field]: { ilike: `%${searchTerm}%` } }));
+                    }
+                    const joinFields = {};
+                    const derefs = Array.isArray(dereference)
+                    ? dereference
+                    : !dereference
+                        ? []
+                        : [dereference];
+                    derefs.forEach((f) => {
+                    const field = table.getField(f);
+                    if (field?.attributes?.summary_field)
+                        joinFields[`${f}_${field?.attributes?.summary_field}`] = {
+                        ref: f,
+                        target: field?.attributes?.summary_field,
+                        };
+                    });
+                    try {
+                    rows = await table.getJoinedRows({
+                        where: qstate,
+                        joinFields,
+                        limit: use_limit,
+                        offset: use_offset,
+                        orderDesc:
+                        (sortDesc && sortDesc !== "false") || tabulator_dir == "desc",
+                        orderBy: orderByField?.name || undefined,
+                        forPublic: !(req.user || user),
+                        forUser: req.user || user,
+                    });
+                    } catch (e) {
+                    console.error(e);
+                    res.json({ error: "API error" });
+                    return;
+                    }
+                }
+
+                // Limit columns if 'colunas' is provided (your custom logic)
+                if (req.query.colunas && typeof req.query.colunas === 'string') {
+                    const requested = req.query.colunas.split(',').map(c => c.trim()).filter(Boolean);
+                    if (requested.length > 0 && requested.length <= 10) {
+                    rows = rows.map(row => 
+                        Object.fromEntries(
+                        Object.entries(row).filter(([key]) => requested.includes(key))
+                        )
+                    );
+                    }
+                }
+
+                if (tabulator_pagination_format) {
+                    const count = await table.countRows();
+                    if (count === null)
+                    res.json({
+                        data: rows.map(limitFields(queryFields || columns)),
+                    });
+                    else
+                    res.json({
+                        last_page: Math.ceil(count / +tabulator_size),
+                        data: rows.map(limitFields(queryFields || columns)),
+                    });
+                } else res.json({ success: rows.map(limitFields(queryFields || columns)) });
+                } else {
+                getState().log(3, `API get ${table.name} not authorized`);
+                res.status(401).json({ error: req.__("Not authorized") });
+                }
+            }
+            )(req, res, next);
+        })
+        );

--- a/index.js
+++ b/index.js
@@ -234,10 +234,10 @@ const selectize = {
                   attrs?.ajax
                     ? `load: async function(query, callback) {
     if (!query.length || query.length<2) return callback();
-    const url = '/api/${field.reftable_name}?${field.attributes.summary_field}=' + query + '&approximate=true' + ( "${attrs.columns_to_fetch ? '&colunas=' + encodeURIComponent(attrs.columns_to_fetch) : ''}" ) + ( "${attrs.where ? '&where=' + encodeURIComponent(attrs.where) : ''}" );
+    const url = '/api/${field.reftable_name}?${field.attributes.summary_field}=' + query + '&approximate=true' + ( "${attrs.columns_to_fetch ? '&colunas=' + encodeURIComponent(attrs.columns_to_fetch) : ''}" );
     if (isWeb) {
       $.ajax({
-        url: url,
+        url: url,s
         type: 'GET',
         dataType: 'json',
         error: function(err) { console.log(err); },
@@ -431,7 +431,7 @@ $('#input${nm}').selectize({
   language: "${default_locale}",
   load: async function(query, callback) {
     if (!query.length || query.length < 2) return callback();
-    const url = '/api/${field.reftable_name}?${field.attributes.summary_field}=' + query + '&approximate=true' + ( "${attrs.columns_to_fetch ? '&colunas=' + encodeURIComponent(attrs.columns_to_fetch) : ''}" ) + ( "${attrs.where ? '&where=' + encodeURIComponent(attrs.where) : ''}" );
+    const url = '/api/${field.reftable_name}?${field.attributes.summary_field}=' + query + '&approximate=true' + ( "${attrs.columns_to_fetch ? '&colunas=' + encodeURIComponent(attrs.columns_to_fetch) : ''}" );
     if (isWeb) {
       $.ajax({
         url: url,
@@ -486,7 +486,7 @@ $('#input${nm}').selectize({
 document.getElementById('input${nm}').addEventListener('RefreshSelectOptions', (e) => { }, false);
 
 window.soc_process_${nm} = (elem) => ()=> {
-  const url = '/api/${field.reftable_name}?${field.attributes.summary_field}=' + query + '&approximate=true' + ( "${attrs.columns_to_fetch ? '&colunas=' + encodeURIComponent(attrs.columns_to_fetch) : ''}" ) + ( "${attrs.where ? '&where=' + encodeURIComponent(attrs.where) : ''}" );
+  const url = '/api/${field.reftable_name}' + ( "${attrs.columns_to_fetch ? '?colunas=' + encodeURIComponent(attrs.columns_to_fetch) : ''}" );
   $.ajax(url, {
     success: function (res, textStatus, request) {
       const dataOptions = [];

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ const selectize = {
 
    /**
    * @type {object[]}
-   */
+   */  
   fill_options_restrict(field, v) {
     if (field?.attributes?.ajax) {
       const pk = Table.findOne(field.reftable_name)?.pk_name;
@@ -234,11 +234,10 @@ const selectize = {
                   attrs?.ajax
                     ? `load: async function(query, callback) {
     if (!query.length || query.length<2) return callback();
-      if (isWeb) {
+    const url = '/api/${field.reftable_name}?${field.attributes.summary_field}=' + query + '&approximate=true' + ( "${attrs.columns_to_fetch ? '&colunas=' + encodeURIComponent(attrs.columns_to_fetch) : ''}" ) + ( "${attrs.where ? '&where=' + encodeURIComponent(attrs.where) : ''}" );
+    if (isWeb) {
       $.ajax({
-        url: '/api/${field.reftable_name}?${
-                        field.attributes.summary_field
-                      }='+query+'&approximate=true' + ( "${attrs.columns_to_fetch ? '&colunas=' + encodeURIComponent(attrs.columns_to_fetch) : ''}" ),
+        url: url,
         type: 'GET',
         dataType: 'json',
         error: function(err) { console.log(err); },
@@ -357,14 +356,12 @@ const search_or_create_selectize = {
         {
           class: `form-control form-select ${cls} ${field.class || ""}`,
           "data-fieldname": field.form_name,
-
           name: text_attr(nm0),
           id: `input${nm}`,
           disabled: attrs.disabled,
           readonly: attrs.readonly,
           onChange: attrs.onChange,
           autocomplete: "off",
-
           ...(attrs?.dynamic_where
             ? {
                 "data-selected": v,
@@ -434,9 +431,7 @@ $('#input${nm}').selectize({
   language: "${default_locale}",
   load: async function(query, callback) {
     if (!query.length || query.length < 2) return callback();
-    const url = '/api/${field.reftable_name}?${
-      field.attributes.summary_field
-    }=' + query + '&approximate=true' + ( "${attrs.columns_to_fetch ? '&colunas=' + encodeURIComponent(attrs.columns_to_fetch) : ''}" );
+    const url = '/api/${field.reftable_name}?${field.attributes.summary_field}=' + query + '&approximate=true' + ( "${attrs.columns_to_fetch ? '&colunas=' + encodeURIComponent(attrs.columns_to_fetch) : ''}" ) + ( "${attrs.where ? '&where=' + encodeURIComponent(attrs.where) : ''}" );
     if (isWeb) {
       $.ajax({
         url: url,
@@ -491,7 +486,7 @@ $('#input${nm}').selectize({
 document.getElementById('input${nm}').addEventListener('RefreshSelectOptions', (e) => { }, false);
 
 window.soc_process_${nm} = (elem) => ()=> {
-  const url = '/api/${field.reftable_name}' + ( "${attrs.columns_to_fetch ? '?colunas=' + encodeURIComponent(attrs.columns_to_fetch) : ''}" );
+  const url = '/api/${field.reftable_name}?${field.attributes.summary_field}=' + query + '&approximate=true' + ( "${attrs.columns_to_fetch ? '&colunas=' + encodeURIComponent(attrs.columns_to_fetch) : ''}" ) + ( "${attrs.where ? '&where=' + encodeURIComponent(attrs.where) : ''}" );
   $.ajax(url, {
     success: function (res, textStatus, request) {
       const dataOptions = [];

--- a/index.js
+++ b/index.js
@@ -305,26 +305,6 @@ const selectize = {
     );
   },
 };
-const configuration_workflow = () =>
-  new Workflow({
-    steps: [
-      {
-        name: "everything",
-        form: async (context) => {
-          return new Form({
-            fields: [
-              {
-                name: "everything",
-                label: "Selectize everything",
-                sublabel: "Apply selectize everywhere possible",
-                type: "Bool",
-              },
-            ],
-          });
-        },
-      },
-    ],
-  });
 
 const search_or_create_selectize = {
   /** @type {string} */
@@ -553,7 +533,6 @@ const default_locale = getState().getConfig("default_locale", "en");
 module.exports = {
   sc_plugin_api_version: 1,
   fieldviews,
-  configuration_workflow,
   plugin_name: "selectize",
   //viewtemplates: [require("./edit-nton")],
   headers: [

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@saltcorn/selectize",
-  "version": "0.2.8",
+  "version": "0.3.0",
   "description": "Typeahead fieldviews based on seletize.js",
   "main": "index.js",
   "dependencies": {
     "@saltcorn/data": "^0.6.0",
     "@saltcorn/markup": "^0.6.0"
   },
-  "author": "Tom Nielsen",
+  "author": "Tom Nielsen & Asrty",
   "license": "MIT",
   "eslintConfig": {
     "extends": "eslint:recommended",


### PR DESCRIPTION
# New Selectize Plugin Update for Saltcorn
This update introduces enhanced functionality to the Selectize plugin in Saltcorn, focusing on customizable AJAX responses and optimized data fetching. It allows users to format dropdown labels dynamically (e.g., combining fields like name and RG) and limit fetched columns for better performance, without altering the database. The backend modifications ensure the API supports these features securely.

## Key Changes

- **✅AJAX Response Formatting:** Customize how options appear in the dropdown using placeholders like {nome} - {rg}.
- **✅Column Limiting:** Specify fields to fetch (e.g., "id,name,rg") to reduce data transfer.
- **❌Multiple search support:** Search across multiple fields (e.g., partial matches on name, RG, id) for more flexible queries.
- **❌No bug fixes:** Unresolved syntax issues, dynamic "where" filtering, and bidirectional autofill (not implemented).

These improvements make Selectize more efficient for large datasets and complex forms, with no breaking changes to existing setups.
